### PR TITLE
Recipe related changes

### DIFF
--- a/common/src/main/java/dev/alexnijjar/extractinator/Extractinator.java
+++ b/common/src/main/java/dev/alexnijjar/extractinator/Extractinator.java
@@ -3,6 +3,7 @@ package dev.alexnijjar.extractinator;
 import com.teamresourceful.resourcefulconfig.common.config.Configurator;
 import dev.alexnijjar.extractinator.config.ExtractinatorConfig;
 import dev.alexnijjar.extractinator.registry.*;
+import dev.alexnijjar.extractinator.util.ModUtils;
 
 public class Extractinator {
     public static final String MOD_ID = "extractinator";
@@ -17,5 +18,6 @@ public class Extractinator {
         ModRecipeTypes.RECIPE_TYPES.init();
         ModRecipeSerializers.RECIPE_SERIALIZERS.init();
         ModFeatures.FEATURES.init();
+	    ModUtils.clearCache();
     }
 }

--- a/common/src/main/java/dev/alexnijjar/extractinator/recipes/ExtractinatorRecipe.java
+++ b/common/src/main/java/dev/alexnijjar/extractinator/recipes/ExtractinatorRecipe.java
@@ -21,6 +21,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
@@ -79,6 +80,10 @@ public record ExtractinatorRecipe(ResourceLocation id, Ingredient input,
     public static ExtractinatorRecipe findFirst(Level level, Predicate<ExtractinatorRecipe> filter) {
         return getRecipes(level).stream().filter(filter).findFirst().orElse(null);
     }
+
+	public static List<ExtractinatorRecipe> findMatching(Level level, Predicate<ExtractinatorRecipe> filter) {
+		return getRecipes(level).stream().filter(filter).collect(Collectors.toList());
+	}
 
     public static List<ExtractinatorRecipe> getRecipes(Level level) {
         return level.getRecipeManager().getAllRecipesFor(ModRecipeTypes.EXTRACTINATOR_RECIPE.get());

--- a/common/src/main/java/dev/alexnijjar/extractinator/util/ModUtils.java
+++ b/common/src/main/java/dev/alexnijjar/extractinator/util/ModUtils.java
@@ -2,17 +2,22 @@ package dev.alexnijjar.extractinator.util;
 
 import dev.alexnijjar.extractinator.config.ExtractinatorConfig;
 import dev.alexnijjar.extractinator.recipes.ExtractinatorRecipe;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
-public class
-ModUtils {
+public class ModUtils {
+	private static final Random ModUtilRandom = new Random();
+	private static final Object2ObjectOpenHashMap<Map.Entry<Level, Item>, List<ExtractinatorRecipe>> recipeCacheMap = new Object2ObjectOpenHashMap<>();
     public static List<ItemStack> extractItem(Level level, ItemStack stack) {
-        ExtractinatorRecipe recipe = ExtractinatorRecipe.findFirst(level, f -> f.input().test(stack));
+        ExtractinatorRecipe recipe = getRandomMatching(level, stack);
         if (recipe != null) {
             RandomSource random = level.getRandom();
 
@@ -29,8 +34,20 @@ ModUtils {
         }
         return List.of();
     }
-
+	public static void clearCache() {
+		recipeCacheMap.clear();
+	}
     public static boolean isValidInput(Level level, ItemStack stack) {
-        return ExtractinatorRecipe.getRecipes(level).stream().anyMatch(r -> r.input().test(stack));
+        return recipeCacheMap.containsKey(Map.entry(level, stack.getItem())) || ExtractinatorRecipe.getRecipes(level).stream().anyMatch(r -> r.input().test(stack));
     }
+
+	private static ExtractinatorRecipe getRandomMatching(Level level, ItemStack stack) {
+		Item item = stack.getItem();
+		List<ExtractinatorRecipe> recipes = recipeCacheMap.computeIfAbsent(Map.entry(level, item), (entry) ->
+			 ExtractinatorRecipe.findMatching(level, f -> f.input().test(stack)
+			));
+		if (recipes.isEmpty()) return null;
+		int randomIndex = ModUtilRandom.nextInt(recipes.size());
+		return recipes.get(randomIndex);
+	}
 }


### PR DESCRIPTION
Caches recipe by <Level, Item> key

this cache is invalidated when reload happens.


Picks randomly from recipes if multiple recipe exists

supports datapack recipes. 